### PR TITLE
Fixed TE Overall Fantasy Standings Table

### DIFF
--- a/R/create_gt_ovr_fantasy_standings.R
+++ b/R/create_gt_ovr_fantasy_standings.R
@@ -655,13 +655,20 @@ table_ovr_te_fantasy <- function(num_players = NULL,
                                  output_dir = NULL
 ) {
 
-  te_pbp_stats <- nuclearff::get_wr_pbp_stats(pbp_db,
+  te_pbp_stats <- nuclearff::get_te_pbp_stats(pbp_db,
                                               pbp_db_tbl,
                                               seasons,
                                               week_min = 1
   ) %>%
     # Clean up player names in defined player column
-    nuclearff::replace_player_names(player_col = "player_display_name")
+    nuclearff::replace_player_names(player_col = "player_display_name") %>%
+    # Clean up team names e.g., LA to LAR
+    nuclearff::replace_team_names() %>%
+    # Redefine position for the strange case of Taysom Hill to "TE"
+    dplyr::mutate(position = dplyr::case_when(
+      player_display_name == "Taysom Hill" ~ "TE",
+      TRUE ~ position
+    ))
 
   # Pull WR roster information and player IDs
   te_data <- nuclearff::get_player_data(seasons,
@@ -687,7 +694,7 @@ table_ovr_te_fantasy <- function(num_players = NULL,
     )
 
   # Add snap share to data
-  snap_pct <- nuclearff::get_snap_share(season = seasons, pos = "WR") %>%
+  snap_pct <- nuclearff::get_snap_share(season = seasons, pos = "TE") %>%
     # Clean up player names in defined player column
     nuclearff::replace_player_names(player_col = "player")
 
@@ -717,10 +724,10 @@ table_ovr_te_fantasy <- function(num_players = NULL,
     ) %>%
     # Arrange by total fantasy points descending
     dplyr::arrange(dplyr::desc(fpts)) %>%
-    # Only keep the top 16 WR
+    # Only keep the top 16 TE
     utils::head(num_players) %>%
-    # mutate(OVR = 1:16) %>%    # Add the OVERALL column
-    mutate(OVR = paste0("WR", 1:num_players)) %>%  # Combine "WR" with the numbers 1 to 16
+    # Combine "TE" with the numbers 1 to 16
+    mutate(OVR = paste0("TE", 1:num_players)) %>%
     select(OVR, everything()) # Move OVERALL to the first column
 
   # Get the max week - current week


### PR DESCRIPTION
<!--
PR should reference issue that it addresses.
Example: "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->

Reference: Issue #14 

## REASON
<!--Why do you need this feature or what is the enhancement?-->

Fantasy standings table for TEs needs to be fixed. There are a few issues:

- [x] OVR labeling includes WR1, WR2 etc.
- [x] TE TGT% is NA
- [x] Issues with Taysom Hill being labeled QB in PBP data
- [x] Clean up team names (e.g., LA to LAR for Colby Parkinson TE) 

## DESIGN
<!--A concise description (design) of the enhancement.--->

No changes to design, added small changes in function code.

## IMPACT
<!--Will the enhancement change existing APIs or add something new?-->

TE fantasy standings tables now work properly.
